### PR TITLE
Add mastodon action workflow

### DIFF
--- a/.github/workflows/bot-post-mastodon.yaml
+++ b/.github/workflows/bot-post-mastodon.yaml
@@ -1,0 +1,33 @@
+name: Post content automatically to Mastodon
+
+on:
+  schedule:
+    # Runs at 9AM every weekday
+    # https://crontab.guru/#0_9_*_*_1-5
+    - cron:  '0 9 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  run-python-script:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Run Python script
+      id: run-script
+      run: |
+        echo "OUTPUT=$(python3 scripts/social-media-bot/bot-content.py) >> $GITHUB_ENV
+    - name: Send toot to Mastodon
+      id: mastodon
+      uses: cbrgm/mastodon-github-action@v2
+      with:
+          access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }} # access token
+          url: ${{ secrets.MASTODON_URL }} # https://example.social
+          message: ${{ env.OUTPUT }}


### PR DESCRIPTION
Hi 👋 This proposes a GitHub action which in order does the following:

* Runs every weekday at 9AM (can be adjusted of course) OR when manually activated
* Checks out the repository (containing the script we want to run)
* Sets up python
* Runs the python script and saves the output to a new variable called `OUTPUT`
* Sends a toot using the `mastodon-github-action`

In order to test this, the repository needs to have the following environment variables (Settings -> Secrets and variables -> Actions). I recommend adding these as repository secrets.

- [ ] `MASTODON_ACCESS_TOKEN`
- [ ] `MASTODON_URL`

I have not been able to test this locally (because GitHub actions require quite the setup to do so).